### PR TITLE
Fix predictions command in README

### DIFF
--- a/language/question_answering/bert_joint/README.md
+++ b/language/question_answering/bert_joint/README.md
@@ -69,7 +69,8 @@ python -m language.question_answering.bert_joint.run_nq \
   --predict_file=tiny-dev/nq-dev-sample.no-annot.jsonl.gz \
   --init_checkpoint=bert-joint-baseline/bert_joint.ckpt \
   --do_predict \
-  --output_dir=bert_model_output
+  --output_dir=bert_model_output \
+  --output_prediction_file=bert_model_output/predictions.json
 
 python -m natural_questions.nq_eval \
   --logtostderr \


### PR DESCRIPTION
Just a small fix to the README. Without the output_prediction_file flag the run_nq.py script outputs an error:
"ValueError: --output_prediction_file must be defined in predict mode."