### PR TITLE
Adds option for throwing out examples when a copy-from-utterance action cannot be created.

### DIFF
--- a/language/xsp/data_preprocessing/abstract_sql_converters.py
+++ b/language/xsp/data_preprocessing/abstract_sql_converters.py
@@ -171,14 +171,16 @@ def populate_example_from_sql_spans(sql_spans, example):
     if sql_span.sql_token:
       _add_generate_action(sql_span.sql_token, example)
     elif sql_span.value_literal:
-      successful_copy = _add_value_literal(sql_span.value_literal, example) and successful_copy
+      successful_copy = _add_value_literal(
+          sql_span.value_literal, example) and successful_copy
     elif sql_span.column:
       _add_column_copy(sql_span.column.table_name, sql_span.column.column_name,
                        example)
     elif sql_span.table_name:
       _add_table_copy(sql_span.table_name, example)
     elif sql_span.nested_statement:
-      successful_copy = populate_example_from_sql_spans(sql_span.nested_statement, example) and successful_copy
+      successful_copy = populate_example_from_sql_spans(
+          sql_span.nested_statement, example) and successful_copy
     else:
       raise ParseError('Invalid SqlSpan: %s' % sql_span)
   return successful_copy

--- a/language/xsp/data_preprocessing/abstract_sql_converters.py
+++ b/language/xsp/data_preprocessing/abstract_sql_converters.py
@@ -249,6 +249,16 @@ def get_sql_spans_from_query(example):
   return _get_sql_spans_from_actions(example.gold_sql_query.actions)
 
 
+def wikisql_db_to_table_tuples(db_name, db):
+  """Return list of abstract_sql.TableSchema from a dictionary describing a database."""
+  table_schemas = list()
+  for table_name, columns in db.items():
+    column_names = [column['field name'].lower() for column in columns]
+    table_schemas.append(abstract_sql.TableSchema(table_name=table_name.lower(),
+                                                  column_names=column_names))
+  return table_schemas
+
+
 def spider_db_to_table_tuples(db):
   """Return list of abstract_sql.TableSchema from spider json."""
   # The format of the db json object is documented here:
@@ -348,6 +358,13 @@ def spider_table_schemas_map(schema):
   # The format of the schema json object is documented here:
   # https://github.com/taoyds/spider#tables
   return {db['db_id']: spider_db_to_table_tuples(db) for db in schema}
+
+
+def wikisql_table_schemas_map(schema):
+  """Returns map of database id to a list of TableSchema tuples."""
+  # The format of the schema json object is documented here:
+  # https://github.com/taoyds/wikisql#tables
+  return {db_name: wikisql_db_to_table_tuples(db_name, db) for db_name, db in schema.items()}
 
 
 def spider_foreign_keys_map(schema):

--- a/language/xsp/data_preprocessing/abstract_sql_converters.py
+++ b/language/xsp/data_preprocessing/abstract_sql_converters.py
@@ -178,7 +178,7 @@ def populate_example_from_sql_spans(sql_spans, example):
     elif sql_span.table_name:
       _add_table_copy(sql_span.table_name, example)
     elif sql_span.nested_statement:
-      populate_example_from_sql_spans(sql_span.nested_statement, example)
+      successful_copy = populate_example_from_sql_spans(sql_span.nested_statement, example) and successful_copy
     else:
       raise ParseError('Invalid SqlSpan: %s' % sql_span)
   return successful_copy

--- a/language/xsp/data_preprocessing/abstract_sql_converters.py
+++ b/language/xsp/data_preprocessing/abstract_sql_converters.py
@@ -21,6 +21,7 @@ from __future__ import print_function
 from language.xsp.data_preprocessing import abstract_sql
 from language.xsp.data_preprocessing import schema_utils
 
+from language.xsp.data_preprocessing.sql_parsing import VALID_GENERATED_TOKENS
 from language.xsp.data_preprocessing.sql_utils import SchemaEntityCopy
 from language.xsp.data_preprocessing.sql_utils import SQLAction
 
@@ -104,8 +105,6 @@ def _add_value_literal(item_str, example):
             utterance_copy=example.model_input.utterance_wordpieces[i])
         example.gold_sql_query.actions.append(action)
       return True
-    print('WARNING: Could not find the value ' + item_str +
-          ' to copy from input ' + example.model_input.original_utterance)
     return False
 
   # First, check if this string could be copied from the wordpiece-tokenized
@@ -114,10 +113,10 @@ def _add_value_literal(item_str, example):
   if item_str.lower() in example.model_input.original_utterance.lower():
     success = find_and_add_copy_from_text(item_str)
 
-    if not success:
+    if not success or item_str in VALID_GENERATED_TOKENS:
       example.gold_sql_query.actions.append(SQLAction(symbol=item_str))
 
-    return
+    return success or item_str in VALID_GENERATED_TOKENS
 
   elif item_str.startswith('\'') and item_str.endswith('\''):
     quote_type = '\''
@@ -129,30 +128,32 @@ def _add_value_literal(item_str, example):
       example.gold_sql_query.actions.append(SQLAction(symbol=quote_type))
 
       success = find_and_add_copy_from_text(item_str[1:-1])
-      if not success:
+      if not success or item_str in VALID_GENERATED_TOKENS:
         example.gold_sql_query.actions.append(SQLAction(symbol=item_str))
 
       example.gold_sql_query.actions.append(SQLAction(symbol=quote_type))
 
-      return
+      return success or item_str in VALID_GENERATED_TOKENS
     elif item_str[1] == '%' and item_str[-2] == '%' and item_str[2:-2].lower(
     ) in example.model_input.original_utterance.lower():
       example.gold_sql_query.actions.append(SQLAction(symbol=quote_type))
       example.gold_sql_query.actions.append(SQLAction(symbol='%'))
 
       success = find_and_add_copy_from_text(item_str[2:-2])
-      if not success:
+      if not success or item_str in VALID_GENERATED_TOKENS:
         example.gold_sql_query.actions.append(SQLAction(symbol=item_str[2:-2]))
 
       example.gold_sql_query.actions.append(SQLAction(symbol='%'))
       example.gold_sql_query.actions.append(SQLAction(symbol=quote_type))
 
-      return
+      return success or item_str in VALID_GENERATED_TOKENS
 
   # Just add it as choice from the output vocabulary
   if u'u s a' in item_str:
     raise ValueError('WHAT????????')
   example.gold_sql_query.actions.append(SQLAction(symbol=item_str))
+
+  return item_str in VALID_GENERATED_TOKENS
 
 
 def populate_example_from_sql_spans(sql_spans, example):
@@ -165,11 +166,12 @@ def populate_example_from_sql_spans(sql_spans, example):
   Raises:
     ParseError: if the SQL query can't be parsed.
   """
+  successful_copy = True
   for sql_span in sql_spans:
     if sql_span.sql_token:
       _add_generate_action(sql_span.sql_token, example)
     elif sql_span.value_literal:
-      _add_value_literal(sql_span.value_literal, example)
+      successful_copy = _add_value_literal(sql_span.value_literal, example) and successful_copy
     elif sql_span.column:
       _add_column_copy(sql_span.column.table_name, sql_span.column.column_name,
                        example)
@@ -179,6 +181,7 @@ def populate_example_from_sql_spans(sql_spans, example):
       populate_example_from_sql_spans(sql_span.nested_statement, example)
     else:
       raise ParseError('Invalid SqlSpan: %s' % sql_span)
+  return successful_copy
 
 
 def _nested_statement_end_idx(sql_query, action_idx):
@@ -541,7 +544,7 @@ def populate_abstract_sql(example, sql_string, table_schemas):
   """
   sql_spans = abstract_sql.sql_to_sql_spans(sql_string, table_schemas)
   sql_spans = abstract_sql.replace_from_clause(sql_spans)
-  populate_example_from_sql_spans(sql_spans, example)
+  return populate_example_from_sql_spans(sql_spans, example)
 
 
 def restore_predicted_sql(sql_string, table_schemas, foreign_keys):

--- a/language/xsp/data_preprocessing/convert_to_examples.py
+++ b/language/xsp/data_preprocessing/convert_to_examples.py
@@ -118,10 +118,6 @@ def process_spider(output_file, debugging_file, tokenizer):
 
 def process_wikisql(output_file, debugging_file, tokenizer):
   """Loads, converts, and writes WikiSQL examples to the standard format."""
-  # TODO(alanesuhr,petershaw): Support asql for this dataset.
-  if FLAGS.generate_sql and FLAGS.abstract_sql:
-    raise NotImplementedError(
-        'Abstract SQL currently only supported for SPIDER.')
 
   if len(FLAGS.splits) > 1:
     raise ValueError('Not expecting more than one split for WikiSQL.')
@@ -140,12 +136,17 @@ def process_wikisql(output_file, debugging_file, tokenizer):
     load_wikisql_tables(os.path.join(FLAGS.input_filepath,
                                      split + '.tables.jsonl'))
 
+  wikisql_table_schemas_map = abstract_sql_converters.wikisql_table_schemas_map(
+      table_definitions)
+
   for input_example in paired_data:
     example = \
       convert_wikisql(input_example, table_definitions[input_example[2]],
                       tokenizer,
                       FLAGS.generate_sql,
-                      FLAGS.anonymize_values)
+                      FLAGS.anonymize_values,
+                      FLAGS.abstract_sql,
+                      tables_schema=wikisql_table_schemas_map[input_example[2]])
     if example:
       output_file.write(json.dumps(example.to_json()) + '\n')
       num_examples_created += 1

--- a/language/xsp/data_preprocessing/convert_to_examples.py
+++ b/language/xsp/data_preprocessing/convert_to_examples.py
@@ -22,6 +22,8 @@ import os
 
 from absl import app
 from absl import flags
+import tensorflow.gfile as gfile
+
 from bert.tokenization import FullTokenizer
 from language.xsp.data_preprocessing import abstract_sql
 from language.xsp.data_preprocessing import abstract_sql_converters
@@ -33,7 +35,6 @@ from language.xsp.data_preprocessing.spider_preprocessing import load_spider_exa
 from language.xsp.data_preprocessing.spider_preprocessing import load_spider_tables
 from language.xsp.data_preprocessing.wikisql_preprocessing import convert_wikisql
 from language.xsp.data_preprocessing.wikisql_preprocessing import load_wikisql_tables
-import tensorflow.gfile as gfile
 
 FLAGS = flags.FLAGS
 
@@ -55,7 +56,11 @@ flags.DEFINE_bool('generate_sql', False,
 
 flags.DEFINE_bool('anonymize_values', False, 'Whether to anonymize values.')
 
-flags.DEFINE_bool('allow_value_generation', False, 'Whether to allow query values (that should be copied from the input) to be produced through generation actions (i.e., not copied). If False, examples where copying actions cannot be determined will be thrown out.')
+flags.DEFINE_bool('allow_value_generation', False,
+                  'Whether to allow query values (that should be copied from '
+                  'the input) to be produced through generation actions (i.e.,'
+                  ' not copied). If False, examples where copying actions '
+                  'cannot be determined will be thrown out.')
 
 flags.DEFINE_bool(
     'abstract_sql', True,

--- a/language/xsp/data_preprocessing/convert_to_examples.py
+++ b/language/xsp/data_preprocessing/convert_to_examples.py
@@ -55,6 +55,8 @@ flags.DEFINE_bool('generate_sql', False,
 
 flags.DEFINE_bool('anonymize_values', False, 'Whether to anonymize values.')
 
+flags.DEFINE_bool('allow_value_generation', False, 'Whether to allow query values (that should be copied from the input) to be produced through generation actions (i.e., not copied). If False, examples where copying actions cannot be determined will be thrown out.')
+
 flags.DEFINE_bool(
     'abstract_sql', True,
     'Whether to provide SQL labels using under-specified FROM clauses.')
@@ -100,7 +102,8 @@ def process_spider(output_file, debugging_file, tokenizer):
           FLAGS.generate_sql,
           FLAGS.anonymize_values,
           abstract_sql=FLAGS.abstract_sql,
-          table_schemas=spider_table_schemas_map[example_db])
+          table_schemas=spider_table_schemas_map[example_db],
+          allow_value_generation=FLAGS.allow_value_generation)
     except abstract_sql.UnsupportedSqlError as e:
       print(e)
       example = None
@@ -146,7 +149,8 @@ def process_wikisql(output_file, debugging_file, tokenizer):
                       FLAGS.generate_sql,
                       FLAGS.anonymize_values,
                       FLAGS.abstract_sql,
-                      tables_schema=wikisql_table_schemas_map[input_example[2]])
+                      tables_schema=wikisql_table_schemas_map[input_example[2]],
+                      allow_value_generation=FLAGS.allow_value_generation)
     if example:
       output_file.write(json.dumps(example.to_json()) + '\n')
       num_examples_created += 1

--- a/language/xsp/data_preprocessing/spider_preprocessing.py
+++ b/language/xsp/data_preprocessing/spider_preprocessing.py
@@ -14,14 +14,14 @@
 # limitations under the License.
 """Contains functions for loading and preprocessing the Spider data."""
 import json
+import sqlparse
+import tensorflow.gfile as gfile
 
 from language.xsp.data_preprocessing import abstract_sql_converters
 from language.xsp.data_preprocessing.nl_to_sql_example import NLToSQLExample
 from language.xsp.data_preprocessing.nl_to_sql_example import populate_utterance
 from language.xsp.data_preprocessing.sql_parsing import populate_sql
 from language.xsp.data_preprocessing.sql_utils import preprocess_sql
-import sqlparse
-import tensorflow.gfile as gfile
 
 WRONG_TRAINING_EXAMPLES = {
     # In this query the SQL query mentions a ref_company_types table that is not
@@ -117,9 +117,8 @@ def convert_spider(spider_example,
   successful_copy = True
   if generate_sql:
     if abstract_sql:
-      successful_copy = abstract_sql_converters.populate_abstract_sql(example,
-                                                    spider_example['query'],
-                                                    table_schemas)
+      successful_copy = abstract_sql_converters.populate_abstract_sql(
+          example, spider_example['query'], table_schemas)
     else:
       successful_copy = populate_sql(sql_query, example, anonymize_values)
 

--- a/language/xsp/data_preprocessing/spider_preprocessing.py
+++ b/language/xsp/data_preprocessing/spider_preprocessing.py
@@ -126,7 +126,6 @@ def convert_spider(spider_example,
   # If the example contained an unsuccessful copy action, and values should not be
   # generated, then return an empty example.
   if not successful_copy and not allow_value_generation:
-    print('Throwing out example')
     return None
 
   return example

--- a/language/xsp/data_preprocessing/spider_preprocessing.py
+++ b/language/xsp/data_preprocessing/spider_preprocessing.py
@@ -85,7 +85,8 @@ def convert_spider(spider_example,
                    generate_sql,
                    anonymize_values,
                    abstract_sql=False,
-                   table_schemas=None):
+                   table_schemas=None,
+                   allow_value_generation=False):
   """Converts a Spider example to the standard format.
 
   Args:
@@ -113,12 +114,19 @@ def convert_spider(spider_example,
                      wordpiece_tokenizer)
 
   # Set the output
+  successful_copy = True
   if generate_sql:
     if abstract_sql:
-      abstract_sql_converters.populate_abstract_sql(example,
+      successful_copy = abstract_sql_converters.populate_abstract_sql(example,
                                                     spider_example['query'],
                                                     table_schemas)
     else:
-      populate_sql(sql_query, example, anonymize_values)
+      successful_copy = populate_sql(sql_query, example, anonymize_values)
+
+  # If the example contained an unsuccessful copy action, and values should not be
+  # generated, then return an empty example.
+  if not successful_copy and not allow_value_generation:
+    print('Throwing out example')
+    return None
 
   return example

--- a/language/xsp/data_preprocessing/sql_parsing.py
+++ b/language/xsp/data_preprocessing/sql_parsing.py
@@ -635,7 +635,7 @@ def _parse_comparison(sql, example, anonymize_values):
       continue
 
     if _is_function(item):
-      _parse_function(item, example, anonymize_values)
+      successful_copy = _parse_function(item, example, anonymize_values) and successful_copy
       continue
 
     if _is_operation(item):

--- a/language/xsp/data_preprocessing/sql_parsing.py
+++ b/language/xsp/data_preprocessing/sql_parsing.py
@@ -134,7 +134,8 @@ def _parse_function(sql, example, anonymize_values):
   successful_copy = True
   for item in sql:
     if _is_parenthesis(item):
-      successful_copy = populate_sql(item, example, anonymize_values) and successful_copy
+      successful_copy = populate_sql(
+          item, example, anonymize_values) and successful_copy
       continue
     if _is_identifier(item) and item.value.lower() in ('count', 'avg', 'min',
                                                        'max', 'sum',
@@ -396,9 +397,11 @@ def _add_simple_value(item, example, anonymize):
   Args:
     item: A string value present in the SQL query.
     example: The NLToSQLExample being constructed.
-    anonymize: Whether to anonymize values (i.e., replace them with a 'value' placeholder).
-  
-  Returns a boolean indicating whether the value could be copied from the input."""
+    anonymize: Whether to anonymize values
+        (i.e., replace them with a 'value' placeholder).
+
+  Returns a boolean indicating whether the value could be copied from
+  the input."""
   if anonymize:
     example.gold_sql_query.actions.append(SQLAction(symbol='value'))
     return True
@@ -443,8 +446,7 @@ def _add_simple_value(item, example, anonymize):
             utterance_copy=example.model_input.utterance_wordpieces[i])
         example.gold_sql_query.actions.append(action)
       return True
-
-    return False 
+    return False
 
   # First, check if this string could be copied from the wordpiece-tokenized
   # inputs.
@@ -505,7 +507,8 @@ def _parse_identifier(sql, example, anonymize_values):
       continue
 
     if _is_identifier(item):
-      successful_copy = _parse_identifier(item, example, anonymize_values) and successful_copy
+      successful_copy = _parse_identifier(
+          item, example, anonymize_values) and successful_copy
       continue
 
     if _is_order(item):
@@ -541,12 +544,14 @@ def _parse_identifier(sql, example, anonymize_values):
           # Generally this means the reference wasn't found i.e., in WikiSQL, a
           # value didn't have quotes, so just add it as a value
           print(e)
-          successful_copy = _add_simple_value(item, example, anonymize_values) and successful_copy
+          successful_copy = _add_simple_value(
+              item, example, anonymize_values) and successful_copy
       continue
 
     if _is_literal(item):
       prev_len = len(example.gold_sql_query.actions)
-      successful_copy = _add_simple_value(item, example, anonymize_values) and successful_copy
+      successful_copy = _add_simple_value(
+          item, example, anonymize_values) and successful_copy
       if len(example.gold_sql_query.actions) == prev_len:
         raise ValueError(
             'Gold query did not change length when adding simple value!')
@@ -565,7 +570,8 @@ def _parse_operation(sql, example, anonymize_values):
     if item.ttype == sqlparse.tokens.Text.Whitespace:
       continue
     if _is_identifier(item):
-      successful_copy = _parse_identifier(item, example, anonymize_values) and successful_copy
+      successful_copy = _parse_identifier(
+          item, example, anonymize_values) and successful_copy
       continue
     if _is_operator(item):
       _add_simple_step(item, example)
@@ -593,11 +599,13 @@ def _parse_identifier_list(sql, example, anonymize_values):
       continue
 
     if _is_identifier(item):
-      successful_copy = _parse_identifier(item, example, anonymize_values) and successful_copy
+      successful_copy = _parse_identifier(
+          item, example, anonymize_values) and successful_copy
       continue
 
     if _is_operation(item):
-      successful_copy = _parse_operation(item, example, anonymize_values) and successful_copy
+      successful_copy = _parse_operation(
+          item, example, anonymize_values) and successful_copy
       continue
     if _is_keyword(item) and item.value.lower() in ('count', 'avg', 'min',
                                                     'max', 'sum'):
@@ -606,7 +614,7 @@ def _parse_identifier_list(sql, example, anonymize_values):
 
     _debug_sql_item(item)
     raise ParseError('Incomplete _parse_identifier_list')
-    
+
   return successful_copy
 
 
@@ -617,29 +625,34 @@ def _parse_comparison(sql, example, anonymize_values):
     if item.ttype == sqlparse.tokens.Text.Whitespace:
       continue
     if _is_identifier(item):
-      successful_copy = _parse_identifier(item, example, anonymize_values) and successful_copy
+      successful_copy = _parse_identifier(
+          item, example, anonymize_values) and successful_copy
       continue
     if _is_comparison_operator(item):
       _add_simple_step(item, example)
       continue
     if _is_literal(item):
       prev_len = len(example.gold_sql_query.actions)
-      successful_copy = _add_simple_value(item, example, anonymize_values) and successful_copy
+      successful_copy = _add_simple_value(
+          item, example, anonymize_values) and successful_copy
       if len(example.gold_sql_query.actions) == prev_len:
         raise ValueError(
             'Gold query did not change length when adding simple value!')
       continue
 
     if _is_parenthesis(item):
-      successful_copy = populate_sql(item, example, anonymize_values) and successful_copy
+      successful_copy = populate_sql(
+          item, example, anonymize_values) and successful_copy
       continue
 
     if _is_function(item):
-      successful_copy = _parse_function(item, example, anonymize_values) and successful_copy
+      successful_copy = _parse_function(
+          item, example, anonymize_values) and successful_copy
       continue
 
     if _is_operation(item):
-      successful_copy = _parse_operation(item, example, anonymize_values) and successful_copy
+      successful_copy = _parse_operation(
+          item, example, anonymize_values) and successful_copy
       continue
 
     _debug_state(item, example)
@@ -660,7 +673,8 @@ def _parse_where(sql, example, anonymize_values):
       continue
 
     if _is_comparison(item):
-      successful_copy = _parse_comparison(item, example, anonymize_values) and successful_copy
+      successful_copy = _parse_comparison(
+          item, example, anonymize_values) and successful_copy
       continue
 
     if _is_comparison_operator(item):
@@ -668,11 +682,13 @@ def _parse_where(sql, example, anonymize_values):
       continue
 
     if _is_identifier(item):
-      successful_copy = _parse_identifier(item, example, anonymize_values) and successful_copy
+      successful_copy = _parse_identifier(
+          item, example, anonymize_values) and successful_copy
       continue
 
     if _is_identifier_list(item):
-      successful_copy = _parse_identifier_list(item, example, anonymize_values) and successful_copy
+      successful_copy = _parse_identifier_list(
+          item, example, anonymize_values) and successful_copy
       continue
 
     if _is_keyword(item) and item.value.lower() in ('between', 'and', 'or'):
@@ -689,7 +705,8 @@ def _parse_where(sql, example, anonymize_values):
 
     if _is_integer(item):
       prev_len = len(example.gold_sql_query.actions)
-      succesful_copy = _add_simple_value(item, example, anonymize_values) and successful_copy
+      succesful_copy = _add_simple_value(
+          item, example, anonymize_values) and successful_copy
       if len(example.gold_sql_query.actions) == prev_len:
         raise ValueError(
             'Gold query did not change length when adding simple value!')
@@ -702,7 +719,8 @@ def _parse_where(sql, example, anonymize_values):
 
     if _is_literal(item):
       prev_len = len(example.gold_sql_query.actions)
-      successful_copy = _add_simple_value(item, example, anonymize_values) and successful_copy
+      successful_copy = _add_simple_value(
+          item, example, anonymize_values) and successful_copy
       if len(example.gold_sql_query.actions) == prev_len:
         raise ValueError(
             'Gold query did not change length when adding simple value!')
@@ -713,7 +731,8 @@ def _parse_where(sql, example, anonymize_values):
       continue
 
     if _is_parenthesis(item):
-      successful_copy = populate_sql(item, example, anonymize_values) and successful_copy
+      successful_copy = populate_sql(
+          item, example, anonymize_values) and successful_copy
       continue
 
     if _is_select(item) or _is_from(item):
@@ -738,7 +757,8 @@ def populate_sql(sql, example, anonymize_values):
     ParseError: if the SQL query can't be parsed.
 
   Returns:
-    Boolean indicating whether all actions copying values from the input utterance were successfully completed.
+    Boolean indicating whether all actions copying values from
+    the input utterance were successfully completed.
   """
   successful_copy = True
   for item in sql:
@@ -754,7 +774,8 @@ def populate_sql(sql, example, anonymize_values):
       continue
 
     if _is_parenthesis(item):
-      successful_copy = populate_sql(item, example, anonymize_values) and successful_copy
+      successful_copy = populate_sql(
+          item, example, anonymize_values) and successful_copy
       continue
 
     if _is_wildcard(item):
@@ -766,19 +787,23 @@ def populate_sql(sql, example, anonymize_values):
       continue
 
     if _is_where(item):
-      successful_copy = _parse_where(item, example, anonymize_values) and successful_copy
+      successful_copy = _parse_where(
+          item, example, anonymize_values) and successful_copy
       continue
 
     if _is_function(item):
-      successful_copy = _parse_function(item, example, anonymize_values) and successful_copy
+      successful_copy = _parse_function(
+          item, example, anonymize_values) and successful_copy
       continue
 
     if _is_identifier(item):
-      successful_copy = _parse_identifier(item, example, anonymize_values) and successful_copy
+      successful_copy = _parse_identifier(
+          item, example, anonymize_values) and successful_copy
       continue
 
     if _is_identifier_list(item):
-      successful_copy = _parse_identifier_list(item, example, anonymize_values) and successful_copy
+      successful_copy = _parse_identifier_list(
+          item, example, anonymize_values) and successful_copy
       continue
 
     if _is_keyword(item) and item.value.lower() in ('group', 'order', 'by',
@@ -793,7 +818,8 @@ def populate_sql(sql, example, anonymize_values):
       continue
 
     if _is_operation(item):
-      successful_copy = _parse_operation(item, example, anonymize_values) and successful_copy
+      successful_copy = _parse_operation(
+          item, example, anonymize_values) and successful_copy
       continue
 
     if _is_keyword(item) and item.value.lower() in ('between', 'and', 'or'):
@@ -829,14 +855,16 @@ def populate_sql(sql, example, anonymize_values):
                                        1].symbol in ('limit', 'between',
                                                      'and')):
       prev_len = len(example.gold_sql_query.actions)
-      successful_copy = _add_simple_value(item, example, anonymize_values) and successful_copy
+      successful_copy = _add_simple_value(
+          item, example, anonymize_values) and successful_copy
       if len(example.gold_sql_query.actions) == prev_len:
         raise ValueError(
             'Gold query did not change length when adding simple value!')
       continue
 
     if _is_comparison(item):
-      successful_copy = _parse_comparison(item, example, anonymize_values) and successful_copy
+      successful_copy = _parse_comparison(
+          item, example, anonymize_values) and successful_copy
       continue
 
     _debug_state(item, example)

--- a/language/xsp/data_preprocessing/sql_parsing.py
+++ b/language/xsp/data_preprocessing/sql_parsing.py
@@ -505,7 +505,7 @@ def _parse_identifier(sql, example, anonymize_values):
       continue
 
     if _is_identifier(item):
-      succesful_copy = _parse_identifier(item, example, anonymize_values) and successful_copy
+      successful_copy = _parse_identifier(item, example, anonymize_values) and successful_copy
       continue
 
     if _is_order(item):

--- a/language/xsp/data_preprocessing/sql_parsing.py
+++ b/language/xsp/data_preprocessing/sql_parsing.py
@@ -23,6 +23,8 @@ from language.xsp.data_preprocessing.sql_utils import SchemaEntityCopy
 from language.xsp.data_preprocessing.sql_utils import SQLAction
 import sqlparse
 
+VALID_GENERATED_TOKENS = {'1'}
+
 
 class ParseError(Exception):
   pass
@@ -129,9 +131,10 @@ def _debug_state(item, example):
 
 def _parse_function(sql, example, anonymize_values):
   """Parse the part relative to a Function in the SQL query."""
+  successful_copy = True
   for item in sql:
     if _is_parenthesis(item):
-      populate_sql(item, example, anonymize_values)
+      successful_copy = populate_sql(item, example, anonymize_values) and successful_copy
       continue
     if _is_identifier(item) and item.value.lower() in ('count', 'avg', 'min',
                                                        'max', 'sum',
@@ -141,6 +144,7 @@ def _parse_function(sql, example, anonymize_values):
 
     _debug_state(item, example)
     raise ParseError('Incomplete _parse_function')
+  return successful_copy
 
 
 def _find_all_entities(token,
@@ -387,10 +391,17 @@ def _find_from_table(item, example, reverse=False):
 
 
 def _add_simple_value(item, example, anonymize):
-  """Adds a value action to the output."""
+  """Adds a value action to the output.
+
+  Args:
+    item: A string value present in the SQL query.
+    example: The NLToSQLExample being constructed.
+    anonymize: Whether to anonymize values (i.e., replace them with a 'value' placeholder).
+  
+  Returns a boolean indicating whether the value could be copied from the input."""
   if anonymize:
     example.gold_sql_query.actions.append(SQLAction(symbol='value'))
-    return
+    return True
 
   # Commenting out the code that anonymizes.
   item_str = str(item)
@@ -432,9 +443,8 @@ def _add_simple_value(item, example, anonymize):
             utterance_copy=example.model_input.utterance_wordpieces[i])
         example.gold_sql_query.actions.append(action)
       return True
-    print('WARNING: Could not find the value ' + item_str +
-          ' to copy from input ' + example.model_input.original_utterance)
-    return False
+
+    return False 
 
   # First, check if this string could be copied from the wordpiece-tokenized
   # inputs.
@@ -442,10 +452,10 @@ def _add_simple_value(item, example, anonymize):
   if item_str.lower() in example.model_input.original_utterance.lower():
     success = find_and_add_copy_from_text(item_str)
 
-    if not success:
+    if not success or item_str in VALID_GENERATED_TOKENS:
       example.gold_sql_query.actions.append(SQLAction(symbol=item_str))
 
-    return
+    return success or item_str in VALID_GENERATED_TOKENS
 
   elif item_str.startswith('\'') and item_str.endswith('\''):
     quote_type = '\''
@@ -457,40 +467,45 @@ def _add_simple_value(item, example, anonymize):
       example.gold_sql_query.actions.append(SQLAction(symbol=quote_type))
 
       success = find_and_add_copy_from_text(item_str[1:-1])
-      if not success:
+      if not success or item in VALID_GENERATED_TOKENS:
         example.gold_sql_query.actions.append(SQLAction(symbol=item_str))
 
       example.gold_sql_query.actions.append(SQLAction(symbol=quote_type))
 
-      return
+      return success or item_str in VALID_GENERATED_TOKENS
     elif item_str[1] == '%' and item_str[-2] == '%' and item_str[2:-2].lower(
     ) in example.model_input.original_utterance.lower():
       example.gold_sql_query.actions.append(SQLAction(symbol=quote_type))
       example.gold_sql_query.actions.append(SQLAction(symbol='%'))
 
       success = find_and_add_copy_from_text(item_str[2:-2])
-      if not success:
+      if not success or item in VALID_GENERATED_TOKENS:
         example.gold_sql_query.actions.append(SQLAction(symbol=item_str[2:-2]))
 
       example.gold_sql_query.actions.append(SQLAction(symbol='%'))
       example.gold_sql_query.actions.append(SQLAction(symbol=quote_type))
 
-      return
+      return success or item_str in VALID_GENERATED_TOKENS
 
   # Just add it as choice from the output vocabulary
   if u'u s a' in item_str:
     raise ValueError('WHAT????????')
+
   example.gold_sql_query.actions.append(SQLAction(symbol=item_str))
+
+  # A value of 1 is used for things like LIMIT 1 when ordering.
+  return item_str in VALID_GENERATED_TOKENS
 
 
 def _parse_identifier(sql, example, anonymize_values):
   """Parse the part relative to an Identifier in the SQL query."""
+  successful_copy = True
   for item in sql:
     if item.ttype == sqlparse.tokens.Text.Whitespace:
       continue
 
     if _is_identifier(item):
-      _parse_identifier(item, example, anonymize_values)
+      succesful_copy = _parse_identifier(item, example, anonymize_values) and successful_copy
       continue
 
     if _is_order(item):
@@ -526,12 +541,12 @@ def _parse_identifier(sql, example, anonymize_values):
           # Generally this means the reference wasn't found i.e., in WikiSQL, a
           # value didn't have quotes, so just add it as a value
           print(e)
-          _add_simple_value(item, example, anonymize_values)
+          successful_copy = _add_simple_value(item, example, anonymize_values) and successful_copy
       continue
 
     if _is_literal(item):
       prev_len = len(example.gold_sql_query.actions)
-      _add_simple_value(item, example, anonymize_values)
+      successful_copy = _add_simple_value(item, example, anonymize_values) and successful_copy
       if len(example.gold_sql_query.actions) == prev_len:
         raise ValueError(
             'Gold query did not change length when adding simple value!')
@@ -540,14 +555,17 @@ def _parse_identifier(sql, example, anonymize_values):
     _debug_state(item, example)
     raise ParseError('Incomplete _parse_identifier')
 
+  return successful_copy
+
 
 def _parse_operation(sql, example, anonymize_values):
   """Parse the part relative to an Operation in the SQL query."""
+  successful_copy = True
   for item in sql:
     if item.ttype == sqlparse.tokens.Text.Whitespace:
       continue
     if _is_identifier(item):
-      _parse_identifier(item, example, anonymize_values)
+      successful_copy = _parse_identifier(item, example, anonymize_values) and successful_copy
       continue
     if _is_operator(item):
       _add_simple_step(item, example)
@@ -556,9 +574,12 @@ def _parse_operation(sql, example, anonymize_values):
     _debug_sql_item(item)
     raise ParseError('Incomplete _parse_operation')
 
+  return successful_copy
+
 
 def _parse_identifier_list(sql, example, anonymize_values):
   """Parse the part relative to an IdentifierList in the SQL query."""
+  successful_copy = True
   for item in sql:
     if item.ttype == sqlparse.tokens.Text.Whitespace:
       continue
@@ -572,11 +593,11 @@ def _parse_identifier_list(sql, example, anonymize_values):
       continue
 
     if _is_identifier(item):
-      _parse_identifier(item, example, anonymize_values)
+      successful_copy = _parse_identifier(item, example, anonymize_values) and successful_copy
       continue
 
     if _is_operation(item):
-      _parse_operation(item, example, anonymize_values)
+      successful_copy = _parse_operation(item, example, anonymize_values) and successful_copy
       continue
     if _is_keyword(item) and item.value.lower() in ('count', 'avg', 'min',
                                                     'max', 'sum'):
@@ -585,29 +606,32 @@ def _parse_identifier_list(sql, example, anonymize_values):
 
     _debug_sql_item(item)
     raise ParseError('Incomplete _parse_identifier_list')
+    
+  return successful_copy
 
 
 def _parse_comparison(sql, example, anonymize_values):
   """Parse the part relative to a comparison in the SQL query."""
+  successful_copy = True
   for item in sql:
     if item.ttype == sqlparse.tokens.Text.Whitespace:
       continue
     if _is_identifier(item):
-      _parse_identifier(item, example, anonymize_values)
+      successful_copy = _parse_identifier(item, example, anonymize_values) and successful_copy
       continue
     if _is_comparison_operator(item):
       _add_simple_step(item, example)
       continue
     if _is_literal(item):
       prev_len = len(example.gold_sql_query.actions)
-      _add_simple_value(item, example, anonymize_values)
+      successful_copy = _add_simple_value(item, example, anonymize_values) and successful_copy
       if len(example.gold_sql_query.actions) == prev_len:
         raise ValueError(
             'Gold query did not change length when adding simple value!')
       continue
 
     if _is_parenthesis(item):
-      populate_sql(item, example, anonymize_values)
+      successful_copy = populate_sql(item, example, anonymize_values) and successful_copy
       continue
 
     if _is_function(item):
@@ -615,15 +639,18 @@ def _parse_comparison(sql, example, anonymize_values):
       continue
 
     if _is_operation(item):
-      _parse_operation(item, example, anonymize_values)
+      successful_copy = _parse_operation(item, example, anonymize_values) and successful_copy
       continue
 
     _debug_state(item, example)
     raise ParseError('Incomplete _parse_comparison')
 
+  return successful_copy
+
 
 def _parse_where(sql, example, anonymize_values):
   """Parse the part relative to the WHERE clause of the SQL query."""
+  successful_copy = True
   for item in sql:
     if item.ttype == sqlparse.tokens.Text.Whitespace:
       continue
@@ -633,7 +660,7 @@ def _parse_where(sql, example, anonymize_values):
       continue
 
     if _is_comparison(item):
-      _parse_comparison(item, example, anonymize_values)
+      successful_copy = _parse_comparison(item, example, anonymize_values) and successful_copy
       continue
 
     if _is_comparison_operator(item):
@@ -641,11 +668,11 @@ def _parse_where(sql, example, anonymize_values):
       continue
 
     if _is_identifier(item):
-      _parse_identifier(item, example, anonymize_values)
+      successful_copy = _parse_identifier(item, example, anonymize_values) and successful_copy
       continue
 
     if _is_identifier_list(item):
-      _parse_identifier_list(item, example, anonymize_values)
+      successful_copy = _parse_identifier_list(item, example, anonymize_values) and successful_copy
       continue
 
     if _is_keyword(item) and item.value.lower() in ('between', 'and', 'or'):
@@ -662,7 +689,7 @@ def _parse_where(sql, example, anonymize_values):
 
     if _is_integer(item):
       prev_len = len(example.gold_sql_query.actions)
-      _add_simple_value(item, example, anonymize_values)
+      succesful_copy = _add_simple_value(item, example, anonymize_values) and successful_copy
       if len(example.gold_sql_query.actions) == prev_len:
         raise ValueError(
             'Gold query did not change length when adding simple value!')
@@ -675,7 +702,7 @@ def _parse_where(sql, example, anonymize_values):
 
     if _is_literal(item):
       prev_len = len(example.gold_sql_query.actions)
-      _add_simple_value(item, example, anonymize_values)
+      successful_copy = _add_simple_value(item, example, anonymize_values) and successful_copy
       if len(example.gold_sql_query.actions) == prev_len:
         raise ValueError(
             'Gold query did not change length when adding simple value!')
@@ -686,7 +713,7 @@ def _parse_where(sql, example, anonymize_values):
       continue
 
     if _is_parenthesis(item):
-      populate_sql(item, example, anonymize_values)
+      successful_copy = populate_sql(item, example, anonymize_values) and successful_copy
       continue
 
     if _is_select(item) or _is_from(item):
@@ -695,6 +722,7 @@ def _parse_where(sql, example, anonymize_values):
 
     _debug_sql_item(item)
     raise ParseError('Incomplete _parse_where')
+  return successful_copy
 
 
 def populate_sql(sql, example, anonymize_values):
@@ -708,7 +736,11 @@ def populate_sql(sql, example, anonymize_values):
 
   Raises:
     ParseError: if the SQL query can't be parsed.
+
+  Returns:
+    Boolean indicating whether all actions copying values from the input utterance were successfully completed.
   """
+  successful_copy = True
   for item in sql:
     if item.ttype == sqlparse.tokens.Text.Whitespace:
       continue
@@ -722,7 +754,7 @@ def populate_sql(sql, example, anonymize_values):
       continue
 
     if _is_parenthesis(item):
-      populate_sql(item, example, anonymize_values)
+      successful_copy = populate_sql(item, example, anonymize_values) and successful_copy
       continue
 
     if _is_wildcard(item):
@@ -734,19 +766,19 @@ def populate_sql(sql, example, anonymize_values):
       continue
 
     if _is_where(item):
-      _parse_where(item, example, anonymize_values)
+      successful_copy = _parse_where(item, example, anonymize_values) and successful_copy
       continue
 
     if _is_function(item):
-      _parse_function(item, example, anonymize_values)
+      successful_copy = _parse_function(item, example, anonymize_values) and successful_copy
       continue
 
     if _is_identifier(item):
-      _parse_identifier(item, example, anonymize_values)
+      successful_copy = _parse_identifier(item, example, anonymize_values) and successful_copy
       continue
 
     if _is_identifier_list(item):
-      _parse_identifier_list(item, example, anonymize_values)
+      successful_copy = _parse_identifier_list(item, example, anonymize_values) and successful_copy
       continue
 
     if _is_keyword(item) and item.value.lower() in ('group', 'order', 'by',
@@ -761,7 +793,7 @@ def populate_sql(sql, example, anonymize_values):
       continue
 
     if _is_operation(item):
-      _parse_operation(item, example, anonymize_values)
+      successful_copy = _parse_operation(item, example, anonymize_values) and successful_copy
       continue
 
     if _is_keyword(item) and item.value.lower() in ('between', 'and', 'or'):
@@ -797,15 +829,16 @@ def populate_sql(sql, example, anonymize_values):
                                        1].symbol in ('limit', 'between',
                                                      'and')):
       prev_len = len(example.gold_sql_query.actions)
-      _add_simple_value(item, example, anonymize_values)
+      successful_copy = _add_simple_value(item, example, anonymize_values) and successful_copy
       if len(example.gold_sql_query.actions) == prev_len:
         raise ValueError(
             'Gold query did not change length when adding simple value!')
       continue
 
     if _is_comparison(item):
-      _parse_comparison(item, example, anonymize_values)
+      successful_copy = _parse_comparison(item, example, anonymize_values) and successful_copy
       continue
 
     _debug_state(item, example)
     raise ParseError('Incomplete _parse_sql')
+  return successful_copy

--- a/language/xsp/data_preprocessing/wikisql_preprocessing.py
+++ b/language/xsp/data_preprocessing/wikisql_preprocessing.py
@@ -98,8 +98,8 @@ def convert_wikisql(input_example,
     if generate_sql:
       try:
         if use_abstract_sql:
-          successful_copy = abstract_sql_converters.populate_abstract_sql(example, sql,
-                                                        tables_schema)
+          successful_copy = abstract_sql_converters.populate_abstract_sql(
+              example, sql, tables_schema)
         else:
           successful_copy = populate_sql(parsed_sql, example, anonymize_values)
       except (ParseError, ValueError, AssertionError, KeyError, IndexError,
@@ -107,7 +107,7 @@ def convert_wikisql(input_example,
         return None
 
     if not successful_copy and not allow_value_generation:
-        return None
+      return None
 
     if example.gold_sql_query.actions[-1].symbol == '=':
       return None

--- a/language/xsp/data_preprocessing/wikisql_preprocessing.py
+++ b/language/xsp/data_preprocessing/wikisql_preprocessing.py
@@ -20,6 +20,8 @@ from __future__ import print_function
 
 import json
 
+from language.xsp.data_preprocessing import abstract_sql
+from language.xsp.data_preprocessing import abstract_sql_converters
 from language.xsp.data_preprocessing.nl_to_sql_example import NLToSQLExample
 from language.xsp.data_preprocessing.nl_to_sql_example import populate_utterance
 from language.xsp.data_preprocessing.sql_parsing import ParseError
@@ -51,7 +53,7 @@ def normalize_entities(entity_name):
 
 
 def convert_wikisql(input_example, schema, tokenizer, generate_sql,
-                    anonymize_values):
+                    anonymize_values, use_abstract_sql, tables_schema=None):
   """Converts a WikiSQL example into a NLToSQLExample."""
   example = NLToSQLExample()
 
@@ -81,7 +83,6 @@ def convert_wikisql(input_example, schema, tokenizer, generate_sql,
     try:
       sql = preprocess_sql(sql)
     except UnicodeDecodeError as e:
-      print('Unicode error: ' + str(e))
       return None
 
     sql = sql.lower()
@@ -89,14 +90,17 @@ def convert_wikisql(input_example, schema, tokenizer, generate_sql,
 
     if generate_sql:
       try:
-        populate_sql(parsed_sql, example, anonymize_values)
+        if use_abstract_sql:
+            abstract_sql_converters.populate_abstract_sql(example,
+                                                          sql,
+                                                          tables_schema)
+        else:
+            populate_sql(parsed_sql, example, anonymize_values)
       except (ParseError, ValueError, AssertionError, KeyError,
-              IndexError) as e:
-        print(e)
+              IndexError, abstract_sql.ParseError, abstract_sql.UnsupportedSqlError) as e:
         return None
 
     if example.gold_sql_query.actions[-1].symbol == '=':
-      print('The last token should not be an equals sign!')
       return None
 
   except UnicodeEncodeError as e:


### PR DESCRIPTION
One exception for generation is the literal `1`, which should be included in the output vocabulary (for things like `LIMIT 1`).