### PR TITLE
bert_extraction - train_victim_squad.sh error fix

### DIFF
--- a/language/bert_extraction/steal_bert_qa/scripts/train_victim_squad.sh
+++ b/language/bert_extraction/steal_bert_qa/scripts/train_victim_squad.sh
@@ -58,4 +58,4 @@ export OUTPUT_DIR=/home/naveen/scratch/google-language-fork/outputDir
 # For SQuAD 2.0, use the script language.bert_extraction.steal_bert_qa.utils.evaluate_squad_2
 python -m language.bert_extraction.steal_bert_qa.utils.evaluate_squad \
   --dataset_file=$SQUAD_DIR/dev-v1.1.json \
-  --predictions_file=$OUTPUT_DIR/predictions.json
+  --prediction_file=$OUTPUT_DIR/predictions.json

--- a/language/bert_extraction/steal_bert_qa/scripts/train_victim_squad.sh
+++ b/language/bert_extraction/steal_bert_qa/scripts/train_victim_squad.sh
@@ -21,41 +21,37 @@ export BERT_DIR=/path/to/bert/uncased_L-24_H-1024_A-16
 export SQUAD_DIR=/path/to/squad
 export OUTPUT_DIR=/path/to/output_dir
 
-export BERT_DIR=/home/naveen/scratch/google-language-fork/bertModelDir/uncased_L-4_H-256_A-4
-export SQUAD_DIR=/home/naveen/scratch/google-language-fork/squadDir
-export OUTPUT_DIR=/home/naveen/scratch/google-language-fork/outputDir
-
 # STEP 1
 # Download the SQuAD datasets. This is a one-time step, can be ignored once done.
-#wget -O $SQUAD_DIR/train-v1.1.json https://rajpurkar.github.io/SQuAD-explorer/dataset/train-v1.1.json
-#wget -O $SQUAD_DIR/train-v2.0.json https://rajpurkar.github.io/SQuAD-explorer/dataset/train-v2.0.json
-#wget -O $SQUAD_DIR/dev-v1.1.json https://rajpurkar.github.io/SQuAD-explorer/dataset/dev-v1.1.json
-#wget -O $SQUAD_DIR/dev-v2.0.json https://rajpurkar.github.io/SQuAD-explorer/dataset/dev-v2.0.json
+wget -O $SQUAD_DIR/train-v1.1.json https://rajpurkar.github.io/SQuAD-explorer/dataset/train-v1.1.json
+wget -O $SQUAD_DIR/train-v2.0.json https://rajpurkar.github.io/SQuAD-explorer/dataset/train-v2.0.json
+wget -O $SQUAD_DIR/dev-v1.1.json https://rajpurkar.github.io/SQuAD-explorer/dataset/dev-v1.1.json
+wget -O $SQUAD_DIR/dev-v2.0.json https://rajpurkar.github.io/SQuAD-explorer/dataset/dev-v2.0.json
 
 # STEP 2
 # Train the victim model
-#python -m language.bert_extraction.steal_bert_qa.models.run_squad \
-#  --exp_name="train_victim_squad" \
-#  --version_2_with_negative=false \
-#  --do_train=true \
-#  --do_predict=true \
-#  --do_lower_case=true \
-#  --save_checkpoints_steps=5000 \
-#  --train_file=$SQUAD_DIR/train-v1.1.json \
-#  --predict_input_file=$SQUAD_DIR/dev-v1.1.json \
-#  --predict_output_dir=$OUTPUT_DIR \
-#  --vocab_file=$BERT_DIR/vocab.txt \
-#  --bert_config_file=$BERT_DIR/bert_config.json \
-#  --init_checkpoint=$BERT_DIR/bert_model.ckpt \
-#  --max_seq_length=384 \
-#  --train_batch_size=32 \
-#  --learning_rate=5e-5 \
-#  --num_train_epochs=3.0 \
-#  --output_dir=$OUTPUT_DIR
+python -m language.bert_extraction.steal_bert_qa.models.run_squad \
+  --exp_name="train_victim_squad" \
+  --version_2_with_negative=false \
+  --do_train=true \
+  --do_predict=true \
+  --do_lower_case=true \
+  --save_checkpoints_steps=5000 \
+  --train_file=$SQUAD_DIR/train-v1.1.json \
+  --predict_input_file=$SQUAD_DIR/dev-v1.1.json \
+  --predict_output_dir=$OUTPUT_DIR \
+  --vocab_file=$BERT_DIR/vocab.txt \
+  --bert_config_file=$BERT_DIR/bert_config.json \
+  --init_checkpoint=$BERT_DIR/bert_model.ckpt \
+  --max_seq_length=384 \
+  --train_batch_size=32 \
+  --learning_rate=5e-5 \
+  --num_train_epochs=3.0 \
+  --output_dir=$OUTPUT_DIR
 
-# STEP 3
-# Evaluate the predictions of the victim model using the SQuAD eval script
-# For SQuAD 2.0, use the script language.bert_extraction.steal_bert_qa.utils.evaluate_squad_2
+ STEP 3
+ Evaluate the predictions of the victim model using the SQuAD eval script
+ For SQuAD 2.0, use the script language.bert_extraction.steal_bert_qa.utils.evaluate_squad_2
 python -m language.bert_extraction.steal_bert_qa.utils.evaluate_squad \
   --dataset_file=$SQUAD_DIR/dev-v1.1.json \
   --prediction_file=$OUTPUT_DIR/predictions.json

--- a/language/bert_extraction/steal_bert_qa/scripts/train_victim_squad.sh
+++ b/language/bert_extraction/steal_bert_qa/scripts/train_victim_squad.sh
@@ -49,9 +49,9 @@ python -m language.bert_extraction.steal_bert_qa.models.run_squad \
   --num_train_epochs=3.0 \
   --output_dir=$OUTPUT_DIR
 
- STEP 3
- Evaluate the predictions of the victim model using the SQuAD eval script
- For SQuAD 2.0, use the script language.bert_extraction.steal_bert_qa.utils.evaluate_squad_2
+# STEP 3
+# Evaluate the predictions of the victim model using the SQuAD eval script
+# For SQuAD 2.0, use the script language.bert_extraction.steal_bert_qa.utils.evaluate_squad_2
 python -m language.bert_extraction.steal_bert_qa.utils.evaluate_squad \
   --dataset_file=$SQUAD_DIR/dev-v1.1.json \
   --prediction_file=$OUTPUT_DIR/predictions.json

--- a/language/bert_extraction/steal_bert_qa/scripts/train_victim_squad.sh
+++ b/language/bert_extraction/steal_bert_qa/scripts/train_victim_squad.sh
@@ -21,33 +21,37 @@ export BERT_DIR=/path/to/bert/uncased_L-24_H-1024_A-16
 export SQUAD_DIR=/path/to/squad
 export OUTPUT_DIR=/path/to/output_dir
 
+export BERT_DIR=/home/naveen/scratch/google-language-fork/bertModelDir/uncased_L-4_H-256_A-4
+export SQUAD_DIR=/home/naveen/scratch/google-language-fork/squadDir
+export OUTPUT_DIR=/home/naveen/scratch/google-language-fork/outputDir
+
 # STEP 1
 # Download the SQuAD datasets. This is a one-time step, can be ignored once done.
-wget -O $SQUAD_DIR/train-v1.1.json https://rajpurkar.github.io/SQuAD-explorer/dataset/train-v1.1.json
-wget -O $SQUAD_DIR/train-v2.0.json https://rajpurkar.github.io/SQuAD-explorer/dataset/train-v2.0.json
-wget -O $SQUAD_DIR/dev-v1.1.json https://rajpurkar.github.io/SQuAD-explorer/dataset/dev-v1.1.json
-wget -O $SQUAD_DIR/dev-v2.0.json https://rajpurkar.github.io/SQuAD-explorer/dataset/dev-v2.0.json
+#wget -O $SQUAD_DIR/train-v1.1.json https://rajpurkar.github.io/SQuAD-explorer/dataset/train-v1.1.json
+#wget -O $SQUAD_DIR/train-v2.0.json https://rajpurkar.github.io/SQuAD-explorer/dataset/train-v2.0.json
+#wget -O $SQUAD_DIR/dev-v1.1.json https://rajpurkar.github.io/SQuAD-explorer/dataset/dev-v1.1.json
+#wget -O $SQUAD_DIR/dev-v2.0.json https://rajpurkar.github.io/SQuAD-explorer/dataset/dev-v2.0.json
 
 # STEP 2
 # Train the victim model
-python -m language.bert_extraction.steal_bert_qa.models.run_squad \
-  --exp_name="train_victim_squad" \
-  --version_2_with_negative=false \
-  --do_train=true \
-  --do_predict=true \
-  --do_lower_case=true \
-  --save_checkpoints_steps=5000 \
-  --train_file=$SQUAD_DIR/train-v1.1.json \
-  --predict_input_file=$SQUAD_DIR/dev-v1.1.json \
-  --predict_output_dir=$OUTPUT_DIR \
-  --vocab_file=$BERT_DIR/vocab.txt \
-  --bert_config_file=$BERT_DIR/bert_config.json \
-  --init_checkpoint=$BERT_DIR/bert_model.ckpt \
-  --max_seq_length=384 \
-  --train_batch_size=32 \
-  --learning_rate=5e-5 \
-  --num_train_epochs=3.0 \
-  --output_dir=$OUTPUT_DIR
+#python -m language.bert_extraction.steal_bert_qa.models.run_squad \
+#  --exp_name="train_victim_squad" \
+#  --version_2_with_negative=false \
+#  --do_train=true \
+#  --do_predict=true \
+#  --do_lower_case=true \
+#  --save_checkpoints_steps=5000 \
+#  --train_file=$SQUAD_DIR/train-v1.1.json \
+#  --predict_input_file=$SQUAD_DIR/dev-v1.1.json \
+#  --predict_output_dir=$OUTPUT_DIR \
+#  --vocab_file=$BERT_DIR/vocab.txt \
+#  --bert_config_file=$BERT_DIR/bert_config.json \
+#  --init_checkpoint=$BERT_DIR/bert_model.ckpt \
+#  --max_seq_length=384 \
+#  --train_batch_size=32 \
+#  --learning_rate=5e-5 \
+#  --num_train_epochs=3.0 \
+#  --output_dir=$OUTPUT_DIR
 
 # STEP 3
 # Evaluate the predictions of the victim model using the SQuAD eval script

--- a/language/bert_extraction/steal_bert_qa/utils/evaluate_squad.py
+++ b/language/bert_extraction/steal_bert_qa/utils/evaluate_squad.py
@@ -22,7 +22,7 @@ import re
 import string
 import tensorflow.compat.v1 as tf
 
-app = tf.compat.v1.app
+app = tf.app
 flags = tf.flags
 gfile = tf.gfile
 logging = tf.logging


### PR DESCRIPTION
Fixes a couple of breaking issues in train_victim_squad.sh  

1. This pair is very prevelant across many python scripts in the "bert_extraction" folder.  
```
import tensorflow.compat.v1 as tf
app = tf.compat.v1.app
```
It throws the error  
`AttributeError: module 'tensorflow._api.v1.compat.v1.compat' has no attribute 'v1'

I use tensorflow 1.15 and elsewhere in the project tf.app() is directly and correctly used. This incorrect usage has been observed in multiple files across bert_extraction project. 

2. A typo on the flag to evaluate_squad.py.
`