### PR TITLE
Replace `tf.compat.v1.app` with `tf.app`

### DIFF
--- a/language/bert_extraction/steal_bert_classifier/data_generation/build_aux_membership.py
+++ b/language/bert_extraction/steal_bert_classifier/data_generation/build_aux_membership.py
@@ -17,7 +17,7 @@ import random
 
 import tensorflow.compat.v1 as tf
 
-app = tf.compat.v1.app
+app = tf.app
 flags = tf.flags
 gfile = tf.gfile
 logging = tf.logging

--- a/language/bert_extraction/steal_bert_classifier/data_generation/build_membership_dataset.py
+++ b/language/bert_extraction/steal_bert_classifier/data_generation/build_membership_dataset.py
@@ -17,7 +17,7 @@ import random
 
 import tensorflow.compat.v1 as tf
 
-app = tf.compat.v1.app
+app = tf.app
 flags = tf.flags
 gfile = tf.gfile
 logging = tf.logging

--- a/language/bert_extraction/steal_bert_classifier/data_generation/merge_dataset_pool_active_learning.py
+++ b/language/bert_extraction/steal_bert_classifier/data_generation/merge_dataset_pool_active_learning.py
@@ -26,7 +26,7 @@ from scipy import stats
 import tensorflow.compat.v1 as tf
 from tqdm import tqdm
 
-app = tf.compat.v1.app
+app = tf.app
 flags = tf.flags
 gfile = tf.gfile
 logging = tf.logging

--- a/language/bert_extraction/steal_bert_classifier/data_generation/preprocess_edit_distance_one.py
+++ b/language/bert_extraction/steal_bert_classifier/data_generation/preprocess_edit_distance_one.py
@@ -18,7 +18,7 @@ import random
 
 import tensorflow.compat.v1 as tf
 
-app = tf.compat.v1.app
+app = tf.app
 flags = tf.flags
 gfile = tf.gfile
 logging = tf.logging

--- a/language/bert_extraction/steal_bert_classifier/data_generation/preprocess_random.py
+++ b/language/bert_extraction/steal_bert_classifier/data_generation/preprocess_random.py
@@ -20,7 +20,7 @@ from bert_extraction.steal_bert_classifier.data_generation import preprocess_uti
 import tensorflow.compat.v1 as tf
 import tqdm
 
-app = tf.compat.v1.app
+app = tf.app
 flags = tf.flags
 gfile = tf.gfile
 logging = tf.logging

--- a/language/bert_extraction/steal_bert_classifier/data_generation/preprocess_thief_dataset.py
+++ b/language/bert_extraction/steal_bert_classifier/data_generation/preprocess_thief_dataset.py
@@ -20,7 +20,7 @@ from bert_extraction.steal_bert_classifier.data_generation import preprocess_uti
 import tensorflow.compat.v1 as tf
 import tqdm
 
-app = tf.compat.v1.app
+app = tf.app
 flags = tf.flags
 gfile = tf.gfile
 logging = tf.logging

--- a/language/bert_extraction/steal_bert_classifier/embedding_perturbations/merge_shards.py
+++ b/language/bert_extraction/steal_bert_classifier/embedding_perturbations/merge_shards.py
@@ -17,7 +17,7 @@
 import tensorflow.compat.v1 as tf
 from tqdm import tqdm
 
-app = tf.compat.v1.app
+app = tf.app
 flags = tf.flags
 gfile = tf.gfile
 logging = tf.logging

--- a/language/bert_extraction/steal_bert_classifier/utils/dataset_analysis.py
+++ b/language/bert_extraction/steal_bert_classifier/utils/dataset_analysis.py
@@ -19,7 +19,7 @@ from scipy import stats
 import tensorflow.compat.v1 as tf
 from tqdm import tqdm
 
-app = tf.compat.v1.app
+app = tf.app
 flags = tf.flags
 gfile = tf.gfile
 logging = tf.logging

--- a/language/bert_extraction/steal_bert_classifier/utils/merge_datasets_simple.py
+++ b/language/bert_extraction/steal_bert_classifier/utils/merge_datasets_simple.py
@@ -15,7 +15,7 @@
 """Concatenate a list of datasets."""
 import tensorflow.compat.v1 as tf
 
-app = tf.compat.v1.app
+app = tf.app
 flags = tf.flags
 gfile = tf.gfile
 logging = tf.logging

--- a/language/bert_extraction/steal_bert_classifier/utils/pairwise_dataset_analysis.py
+++ b/language/bert_extraction/steal_bert_classifier/utils/pairwise_dataset_analysis.py
@@ -24,7 +24,7 @@ from scipy import stats
 import tensorflow.compat.v1 as tf
 from tqdm import tqdm
 
-app = tf.compat.v1.app
+app = tf.app
 flags = tf.flags
 gfile = tf.gfile
 logging = tf.logging

--- a/language/bert_extraction/steal_bert_classifier/utils/preprocess_distill_input.py
+++ b/language/bert_extraction/steal_bert_classifier/utils/preprocess_distill_input.py
@@ -17,7 +17,7 @@
 import numpy as np
 import tensorflow.compat.v1 as tf
 
-app = tf.compat.v1.app
+app = tf.app
 flags = tf.flags
 gfile = tf.gfile
 logging = tf.logging

--- a/language/bert_extraction/steal_bert_classifier/utils/preprocess_distill_input_watermark.py
+++ b/language/bert_extraction/steal_bert_classifier/utils/preprocess_distill_input_watermark.py
@@ -21,7 +21,7 @@ import random
 import numpy as np
 import tensorflow.compat.v1 as tf
 
-app = tf.compat.v1.app
+app = tf.app
 flags = tf.flags
 gfile = tf.gfile
 logging = tf.logging

--- a/language/bert_extraction/steal_bert_classifier/utils/verify_watermark.py
+++ b/language/bert_extraction/steal_bert_classifier/utils/verify_watermark.py
@@ -17,7 +17,7 @@
 import numpy as np
 import tensorflow.compat.v1 as tf
 
-app = tf.compat.v1.app
+app = tf.app
 flags = tf.flags
 gfile = tf.gfile
 logging = tf.logging

--- a/language/bert_extraction/steal_bert_classifier/utils/wiki103_sentencize.py
+++ b/language/bert_extraction/steal_bert_classifier/utils/wiki103_sentencize.py
@@ -16,7 +16,7 @@
 
 import tensorflow.compat.v1 as tf
 
-app = tf.compat.v1.app
+app = tf.app
 flags = tf.flags
 gfile = tf.gfile
 logging = tf.logging


### PR DESCRIPTION
This patch fixes compilation errors in the steal_bert_classifier subtree where files have the following two lines:
`import tensorflow.compat.v1 as tf`
`app = tf.compat.v1.app`

Credit to @s-zanella.