### PR TITLE
FRUIT Data Processing Pipeline Scripts + Documentation

### DIFF
--- a/language/fruit/README.md
+++ b/language/fruit/README.md
@@ -7,11 +7,11 @@ This is the release for the paper: [FRUIT: Faithfully Reflecting Updated Informa
 
 * (5/12/2022) The data is available now, and the evaluation scripts will be released later.
 
-## Dataset
+## FRUIT-Wiki Dataset
 
 ### Download
 
-To download the FRUIT dataset, run:
+To download the FRUIT-Wiki dataset, run:
 
 ```
 mkdir fruit_dataset
@@ -57,11 +57,16 @@ Each sentence in the source article has a marker with a pair of square brackets 
 
 This means that the first sentence is updated using the context item (0) and (1). Note that the reference is calculated heuristically (excepted for the gold_test data). '[2] [3] [4]' means that the these sentences are copied directly from the source article.
 
-## Raw file
+## Raw Files
 
 Files with name such as article_pairs.update.jsonl-?????-of-00251 are generated using our data extraction pipeline. Each line is a json object describing the source article, the target article and the entity annotations we used to compute the context. The raw files are only in the train folder and the test folder, given the gold_test folder is a subset of the test folder where we clean the data even further with human annotations.
 
 The main purpose of the raw files is for the users who want to create a different version of the input/output files than the EdiT5 processed files.
+
+## Data Collection Pipeline
+
+To enable researchers to apply our data collection pipeline to future Wikipedia snapshots, this repository also contains our data processing code. Please refer to the [README_PIPELINE.md](./README_PIPELINE.md) file for detailed instructions on how to run the different pipeline steps.
+
 
 ## Eval Scripts without t5x
 
@@ -131,4 +136,3 @@ Then an example evaluation run is
    --gin.EVAL_OUTPUT_DIR=\"/tmp/eval\" \
    --gin.DROPOUT_RATE=0
 ```
-

--- a/language/fruit/README_PIPELINE.md
+++ b/language/fruit/README_PIPELINE.md
@@ -1,0 +1,117 @@
+# Data Collection Pipeline
+
+Our data collection pipeline can be used to produce distantly supervised annotations from pairs of Wikipedia snapshots. The pipeline may also be used to process other sources of data, however this may require modification.
+
+In order to run the pipeline you will need [Apache Beam](https://beam.apache.org/) installed. Apache Beam allows for distributed processing of the input data, and supports a variety of execution engines (e.g., Google Cloud Dataflow, Apache Spark, etc.).
+
+The data collection pipeline is comprised of a sequence of steps that transform the data. Each of these steps has a corresponding script in the scripts/ directory that begins with the word `run_`. Here is a basic overview of each step and the sequence they should be applied:
+
+1. `run_convert_to_jsonl.py`: Converts a Wikipedia dump from XML format to jsonl (which is an easier format for processing with Beam). This step must be run separately on the source and target data.
+2. `run_redirect_table_pipeline.py`: Extracts redirects from Wikipedia dump (to ensure accurate entity resolution from wikilinks). This step must be run separately on the source and target data.
+3. `run_process_snapshot_pipeline.py`: Processes the pair of snapshots to extract updated article text and entity mentions.
+4. `run_filter_for_generation_pipeline.py`: Applies operations to the output of the previous step to adjust text length and filter out unwanted data.
+5. `run_to_tfrecords_pipeline.py`: Prepares the output of the previous step for training a particular model. This is where tokenization, insertion of sentinel and control tokens, and conversion to diff format happen.
+
+Each step supports a number of flags that allow the user to customize how the data is processed (use `--help` flag for a brief explanation of each option). Please note that many of the flags were added to explore different approaches for dataset production in early phases of this research and can substantially degrade data quality. For this reason, we recommend using the default settings used to produce the FRUIT-Wiki dataset listed below.
+
+
+## Example: Processing English Wikipedia Snapshots.
+
+For concrete illustration this section lists the sequence of commands run to produce the FRUIT-Wiki dataset. Please note that these commands will be executed using Beam's DirectRunner runner, which will process the data locally using a single process. The runner and other Beam-related settings can be modified by using `--pipeline_options` flag. We direct the reader to the [Beam documentation](https://beam.apache.org/documentation/) for information on how to set this flag for their use case.
+
+### Download XML dumps
+
+You will need to begin with two Wikipedia XML dumps. Current dumps can be downloaded from https://dumps.wikimedia.org/, while historic dumps can be downloaded from https://archive.org/. You will want to download the `enwiki-YYYYMMDD-pages-articles.xml.bz2` file.
+
+For the rest of the steps we'll assume you have the following files:
+- `enwiki-20181120-pages-articles.xml.bz2`
+- `enwiki-20191120-pages-articles.xml.bz2`
+
+### Convert XML to jsonl
+
+Next you will need to process the XML files to a JSONL.
+
+``` {bash}
+python -m language.fruit.scripts.run_convert_to_jsonl \
+ --input_xml enwiki-20181120-pages-articles.xml.bz2 \
+ --output_jsonl enwiki-20181120-pages-articles.jsonl
+
+python -m language.fruit.scripts.run_convert_to_jsonl \
+ --input_xml enwiki-20191120-pages-articles.xml.bz2 \
+ --output_jsonl enwiki-20191120-pages-articles.jsonl
+```
+
+### Extract redirects
+
+``` {bash}
+python -m language.fruit.scripts.run_redirect_table_pipeline \
+ --input_jsonl enwiki-20181120-pages-articles.jsonl  \
+ --output_tsv enwiki-20181120-redirects.tsv \
+
+python -m language.fruit.scripts.run_redirect_table_pipeline \
+ --input_jsonl enwiki-20191120-pages-articles.jsonl  \
+ --output_tsv enwiki-20191120-redirects.tsv \
+```
+
+### Process snapshots
+
+```{bash}
+python -m language.fruit.scripts.run_process_snapshot_pipeline \
+ --target_jsonl enwiki-20191120-pages-articles.jsonl \
+ --source_jsonl enwiki-20181120-pages-articles.jsonl \
+ --output_dir train \
+ --notruncate \
+ --keep_tables \
+ --third_party \
+ --use_source_mentions \
+ --target_redirects enwiki-20191120-redirects.tsv* \
+ --source_redirects enwiki-20181120-redirects.tsv*
+```
+
+### Filter for generation
+
+```{bash}
+python -m language.fruit.scripts.run_filter_for_generation_pipeline \
+ --input_pattern article_pairs.jsonl* \
+ --output_pattern article_pairs.update.jsonl \
+ --nouse_source_mentions
+```
+
+### Prepare for model
+
+In this step you may want to adjust some of the following parameters to prepare the data a certain way.
+
+Here are the ones of interest:
+
+-   `--task`:
+   -   `fullgen`: Generate all of the output text.
+   -   `diff`: Generate only the edits.
+   -   `controllable`: Insert control codes in the input telling the model where to make edits.
+
+-   `--delimiter\_type`:
+
+   -   `text`: Delimit input sentences and evidence using textual delimiters (e.g., [0], [1], (2), (3), etc.)
+   -   `extra_id`: Delimit input sentences and evidence using unique tokens in the model vocab.
+
+-   `--evidence_marker_type`:
+   -   `empty`: Do not add any information about which evidence was used to produce an edit.
+   -   `reference`: Insert reference tokens before each edit telling the model which evidence was used.
+
+Here are the settings used to produce the EdiT5 training data:
+``` {bash}
+python -m language.fruit.scripts.run_to_tfrecords_pipeline \
+ --input_pattern train/article_pairs.jsonl* \
+ --output_pattern train/article_pairs.update.diff.all.reference.tfrecords \
+ --task diff \
+ --delimiter_type text \
+ --evidence_marker_type reference \
+ --noinclude_source \
+ --include_evidence \
+ --include_distractors
+```
+
+## Applying to your own data.
+
+The pipeline above can be applied to process other English Wikipedia snapshots by simply changing the input files.
+For processing other languages you will likely need to edit the `beam_pipelines.py` file to use a more appropriate tokenizer.
+For processing non-Wikipedia data, you will need to prepare the data so that it resembles the format output by the `run_convert_to_jsonl.py` script, and, depending on how entities are annotated, you may also need to modify the `process_snapshot_pipeline` routine in the `beam_pipelines.py` file. For support on creating non-Wikipedia FRUIT datasets please contact Rob Logan at [rloganiv@gmail.com](mailto:rloganiv@gmail.com)

--- a/language/fruit/beam_pipelines_test.py
+++ b/language/fruit/beam_pipelines_test.py
@@ -27,7 +27,7 @@ from language.fruit import rendering_utils
 
 TESTDATA_DIR = "language/fruit/testdata/"
 VOCAB_FILE = (
-    "gs:///t5-data/vocabs/cc_all.32000.100extra/sentencepiece.model")
+    "gs://t5-data/vocabs/cc_all.32000.100extra/sentencepiece.model")
 
 
 class RedirectTablePipelineTest(absltest.TestCase):

--- a/language/fruit/requirements.txt
+++ b/language/fruit/requirements.txt
@@ -4,3 +4,4 @@ nltk==3.7
 numpy==1.21.6
 tensorflow==2.9.1
 tensorflow-text==2.9.0
+tensorflow-datasets==4.6.0

--- a/language/fruit/requirements.txt
+++ b/language/fruit/requirements.txt
@@ -1,0 +1,6 @@
+apache-beam==2.40.0
+matplotlib==3.5.2
+nltk==3.7
+numpy==1.21.6
+tensorflow==2.9.1
+tensorflow-text==2.9.0

--- a/language/fruit/scripts/run_convert_to_jsonl.py
+++ b/language/fruit/scripts/run_convert_to_jsonl.py
@@ -1,0 +1,54 @@
+# coding=utf-8
+# Copyright 2018 The Google AI Language Team Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+r"""Converts a Wikipedia XML dump to JSONL.
+
+There are two reasons we do this:
+  1. To filter down the dump to articles and redirects.
+  2. JSONL is much more amenable to parallel processing.
+"""
+import bz2
+import json
+import os
+
+from absl import app
+from absl import flags
+from absl import logging
+from language.fruit import wiki_utils
+import tqdm
+
+flags.DEFINE_string("input_xml", None, "Input compressed XML file.")
+flags.DEFINE_string("output_jsonl", None, "Ouput JSONL file.")
+
+FLAGS = flags.FLAGS
+
+
+def main(_):
+  openers = {
+      ".xml": open,
+      ".bz2": bz2.open,
+  }
+  filetype = os.path.splitext(FLAGS.input_xml)[-1]
+  opener = openers.get(filetype, open)
+  logging.info("processing file: %s", FLAGS.input_xml)
+  logging.info("filetype: %s", filetype)
+  with opener(FLAGS.input_xml, "r") as xml_file, \
+      open(FLAGS.output_jsonl, "w") as jsonl_file:
+    for page in tqdm.tqdm(wiki_utils.generate_pages(xml_file)):
+      page_json = json.dumps(page, ensure_ascii=False)
+      print(page_json, file=jsonl_file)
+
+
+if __name__ == "__main__":
+  app.run(main)

--- a/language/fruit/scripts/run_filter_for_generation_pipeline.py
+++ b/language/fruit/scripts/run_filter_for_generation_pipeline.py
@@ -1,0 +1,123 @@
+# coding=utf-8
+# Copyright 2018 The Google AI Language Team Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+r"""Applies post-processing to article-evidence pairs.
+
+This pipeline filters out undesirable article-evidence pairs, e.g., ones with
+no evidence, as well as applies truncation strategies to handle long texts and
+updated articles that excessive amounts of supporting evidence.
+"""
+import apache_beam as beam
+from absl import app
+from absl import flags
+from language.fruit import beam_pipelines
+
+FLAGS = flags.FLAGS
+
+flags.DEFINE_string(
+  'input_pattern',
+  default=None,
+  help='Input JSONL files.',
+  required=True,
+)
+
+flags.DEFINE_string(
+  'output_pattern',
+  default=None,
+  help='Ouput tfrecords files.',
+  required=True,
+)
+
+flags.DEFINE_string(
+  'vocab_model_file',
+  default=None,
+  help='Vocabulary for mapping text to ids.',
+  required=True,
+)
+
+flags.DEFINE_integer(
+  'max_article_length',
+  default=512,
+  help='Maximum article length.'
+)
+
+flags.DEFINE_string(
+  'excessive_length_strategy',
+  default='truncate',
+  help='What to do with excessively long text. Options: truncate, discard',
+)
+
+flags.DEFINE_integer(
+  'max_mention_length',
+  default=256,
+  help='Maximum mention length.'
+)
+
+flags.DEFINE_integer(
+  'max_mentions',
+  default=256,
+  help='Maximum number of mentions.',
+)
+
+flags.DEFINE_string(
+  'excessive_mention_strategy',
+  default='truncate',
+  help='What to do with excessive mentions. Options: truncate, discard',
+)
+
+flags.DEFINE_boolean(
+  'use_source_mentions',
+  default=True,
+  help='Whether to filter source mentions from evidence.',
+)
+
+flags.DEFINE_boolean(
+  'include_new_articles',
+  default=False,
+  help='Whether to include new articles (e.g., empty sources).',
+)
+
+flags.DEFINE_list(
+  'pipeline_options',
+  default=['--runner=DirectRunner'],
+  help=(
+    'A comma-separated list of command line arguments to be used as options '
+    'for the beam pipeline.'
+  )
+)
+
+
+def main(_):
+  pipeline_options = beam.options.pipeline_options.PipelineOptions(
+    FLAGS.pipeline_options
+  )
+  pipeline = beam_pipelines.filter_for_generation_pipeline(
+    input_pattern=FLAGS.input_pattern,
+    output_pattern=FLAGS.output_pattern,
+    vocab_model_file=FLAGS.vocab_model_file,
+    max_article_length=FLAGS.max_article_length,
+    excessive_length_strategy=FLAGS.excessive_length_strategy,
+    max_mention_length=FLAGS.max_mention_length,
+    max_mentions=FLAGS.max_mentions,
+    excessive_mention_strategy=FLAGS.excessive_mention_strategy,
+    use_source_mentions=FLAGS.use_source_mentions,
+    include_new_articles=FLAGS.include_new_articles,
+    dry_run=False,
+  )
+  with beam.Pipeline(options=pipeline_options) as p:
+    pipeline(p)
+
+
+if __name__ == '__main__':
+  app.run(main)

--- a/language/fruit/scripts/run_process_snapshot_pipeline.py
+++ b/language/fruit/scripts/run_process_snapshot_pipeline.py
@@ -1,0 +1,125 @@
+# coding=utf-8
+# Copyright 2018 The Google AI Language Team Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+r"""Processes a pair of Wikipedia snapshots to obtain article-update pairs."""
+
+import apache_beam as beam
+from absl import app
+from absl import flags
+from language.fruit import beam_pipelines
+
+FLAGS = flags.FLAGS
+
+flags.DEFINE_string(
+  'source_jsonl',
+  default=None,
+  help='Source Wikipedia JSONL.',
+  required=True,
+)
+
+flags.DEFINE_string(
+  'target_jsonl',
+  default=None,
+  help='Target Wikipedia JSONL.',
+  required=True,
+)
+
+flags.DEFINE_string(
+  'output_dir',
+  default=None,
+  help='Output path.',
+  required=True,
+)
+
+
+flags.DEFINE_string(
+  'source_redirects',
+  default=None,
+  help='Source Wikipedia redirect tsv.',
+  required=True,
+)
+
+flags.DEFINE_string(
+  'target_redirects',
+  default=None,
+  help='Target Wikipedia redirect tsv.',
+  required=True,
+)
+
+flags.DEFINE_boolean(
+  'keep_tables',
+  default=True,
+  help='Whether to keep or remove tables from articles.',
+)
+
+flags.DEFINE_boolean(
+  'third_party',
+  default=True,
+  help=(
+    'Enabling relaxes the assumption of what constitutes supporting evidence '
+    'for an update more strict. "Third party" mentions are updated sentences '
+    'from any article that mention the subject of the article-pair and one '
+    'of the added entities.'
+  ),
+)
+
+flags.DEFINE_boolean(
+  'truncate',
+  default=False,
+  help=(
+    'Enabling strips out any text after the intro paragraph from '
+    'consideration.'
+  ),
+)
+
+flags.DEFINE_boolean(
+  'use_source_mentions',
+  default=False,
+  help=(
+    'Enabling allows mentions from both the source and target article to be '
+    'considered as supporting evidence.'
+  )
+)
+
+flags.DEFINE_list(
+  'pipeline_options',
+  default=['--runner=DirectRunner'],
+  help=(
+    'A comma-separated list of command line arguments to be used as options '
+    'for the beam pipeline.'
+  )
+)
+
+
+def main(_):
+  pipeline_options = beam.options.pipeline_options.PipelineOptions(
+    FLAGS.pipeline_options
+  )
+  pipeline = beam_pipelines.process_snapshot_pipeline(
+    source_jsonl=FLAGS.source_jsonl,
+    target_jsonl=FLAGS.target_jsonl,
+    output_dir=FLAGS.output_dir,
+    source_redirects=FLAGS.source_redirects,
+    target_redirects=FLAGS.target_redirects,
+    keep_tables=FLAGS.keep_tables,
+    third_party=FLAGS.third_party,
+    truncate=FLAGS.truncate,
+    use_source_mentions=FLAGS.use_source_mentions,
+  )
+  with beam.Pipeline(options=pipeline_options) as p:
+    pipeline(p)
+
+
+if __name__ == '__main__':
+  app.run(main)

--- a/language/fruit/scripts/run_redirect_table_pipeline.py
+++ b/language/fruit/scripts/run_redirect_table_pipeline.py
@@ -1,0 +1,61 @@
+# coding=utf-8
+# Copyright 2018 The Google AI Language Team Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+r"""Builds a table of Wikipedia redirects used to improve entity precision/recall."""
+
+import apache_beam as beam
+from absl import app
+from absl import flags
+from language.fruit import beam_pipelines
+
+FLAGS = flags.FLAGS
+
+flags.DEFINE_string(
+  'input_jsonl',
+  default=None,
+  help='Input Wikipedia JSONL.',
+  required=True,
+)
+
+flags.DEFINE_string(
+  'output_tsv',
+  default=None,
+  help='Output tsv path.',
+  required=True,
+)
+
+flags.DEFINE_list(
+  'pipeline_options',
+  default=['--runner=DirectRunner'],
+  help=(
+    'A comma-separated list of command line arguments to be used as options '
+    'for the beam pipeline.'
+  )
+)
+
+
+def main(_):
+  pipeline_options = beam.options.pipeline_options.PipelineOptions(
+    FLAGS.pipeline_options
+  )
+  pipeline = beam_pipelines.redirect_table_pipeline(
+    input_jsonl=FLAGS.input_jsonl,
+    output_tsv=FLAGS.output_tsv,
+  )
+  with beam.Pipeline(options=pipeline_options) as p:
+    pipeline(p)
+
+
+if __name__ == '__main__':
+  app.run(main)

--- a/language/fruit/scripts/run_to_tfrecords_pipeline.py
+++ b/language/fruit/scripts/run_to_tfrecords_pipeline.py
@@ -1,0 +1,168 @@
+# coding=utf-8
+# Copyright 2018 The Google AI Language Team Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+r"""Converts JSONL to tfrecords format for model training/evaluation.
+
+This pipeline also takes care of adding the special sentinel tokens that are
+used by the EdiT5 model, and control codes in the controllable setting.
+"""
+import apache_beam as beam
+from absl import app
+from absl import flags
+from language.fruit import beam_pipelines
+from language.fruit import rendering_utils
+
+Task = rendering_utils.Task
+DelimiterType = rendering_utils.DelimiterType
+EvidenceMarkerType = rendering_utils.EvidenceMarkerType
+
+
+FLAGS = flags.FLAGS
+
+flags.DEFINE_string(
+  'input_pattern',
+  default=None,
+  help='Input JSONL files.',
+  required=True,
+)
+
+flags.DEFINE_string(
+  'output_pattern',
+  default=None,
+  help='Ouput tfrecords files.',
+  required=True,
+)
+
+flags.DEFINE_string(
+  'vocab_model_file',
+  default=None,
+  help='Vocabulary for mapping text to ids.',
+  required=True,
+)
+
+flags.DEFINE_enum_class(
+  'task',
+  default=Task.diff,
+  enum_class=Task,
+  help=(
+    'Specifies the format of the input and output sequences. Options:\n'
+    'diff - the output sequence is the diff between the source and target '
+    'article.\n'
+    'fullgen - the output sequence is the full target article.\n'
+    'controllable - the input sequence includes control tokens indicating '
+    'which sentences should be edited, added, or deleted.'
+  ),
+)
+
+flags.DEFINE_enum_class(
+  'delimiter_type',
+  default=DelimiterType.text,
+  enum_class=DelimiterType,
+  help=(
+    'Specifies the format of delimiters in the input and output sequences. '
+    'Options:\n'
+    'text - Delimiters are represented using text, e.g., (0)/[0]. '
+    'This is the setting used in the original FRUIT experiments.\n'
+    'extra_id - Delimiters are represented using the special extra id tokens '
+    'in T5\'s vocabulary.\n'
+    'NOTE: We did not find substantial variations in performance across these '
+    'settings.'
+  )
+)
+
+flags.DEFINE_boolean(
+  'include_source',
+  default=True,
+  help='Whether the input includes the source article.',
+)
+
+flags.DEFINE_boolean(
+  'include_evidence',
+  default=True,
+  help='Whether the input includes the evidence.',
+)
+
+flags.DEFINE_boolean(
+  'include_distractors',
+  default=True,
+  help=(
+    'Whether the input includes evidence that is not used to produce updates, '
+    'e.g., whether the instances require content selection.'
+  )
+)
+
+flags.DEFINE_enum_class(
+  'evidence_marker_type',
+  default=EvidenceMarkerType.reference,
+  enum_class=EvidenceMarkerType,
+  help=(
+    'Specifies whether or not to include delimiters indicating which pieces '
+    'of evidence support a given edit. Options:\n'
+    'empty - No delimiters are added.\n'
+    'reference - Delimiters are added.'
+  )
+)
+
+flags.DEFINE_integer(
+  'max_input_length',
+  default=1024,
+  help='Maximum sequence length. Longer sequences will be truncated.'
+)
+
+flags.DEFINE_boolean(
+  'filter_no_diff',
+  default=True,
+  help='Whether to filter out articles that were not updated.'
+)
+
+flags.DEFINE_boolean(
+  'plot_lengths',
+  default=False,
+  help='Whether to plot the lengths of the input and output sequences.'
+)
+
+flags.DEFINE_list(
+  'pipeline_options',
+  default=['--runner=DirectRunner'],
+  help=(
+    'A comma-separated list of command line arguments to be used as options '
+    'for the beam pipeline.'
+  )
+)
+
+
+def main(_):
+  pipeline_options = beam.options.pipeline_options.PipelineOptions(
+    FLAGS.pipeline_options
+  )
+  pipeline = beam_pipelines.to_tfrecords_pipeline(
+    input_pattern=FLAGS.input_pattern,
+    output_pattern=FLAGS.output_pattern,
+    vocab_model_file=FLAGS.vocab_model_file,
+    task=FLAGS.task,
+    delimiter_type=FLAGS.delimiter_type,
+    include_source=FLAGS.include_source,
+    include_evidence=FLAGS.include_evidence,
+    include_distractors=FLAGS.include_distractors,
+    evidence_marker_type=FLAGS.evidence_marker_type,
+    max_input_length=FLAGS.max_input_length,
+    filter_no_diff=FLAGS.filter_no_diff,
+    plot_lengths=FLAGS.plot_lengths,
+  )
+  with beam.Pipeline(options=pipeline_options) as p:
+    pipeline(p)
+
+
+if __name__ == '__main__':
+  app.run(main)


### PR DESCRIPTION
Hello, I am one of the FRUIT authors.

This PR adds:
- Scripts wrapping the pipelines in `language/fruit/beam_pipelines.py` to facilitate running on different beam execution engines.
- Documentation of how to reproduce the FRUIT-Wiki training dataset, and apply the data collection pipeline to other sources of data.